### PR TITLE
CBP-21065 [BE] Replace all usages of /v2/workflows/runs/artifactinfos in actions with /v3/artifactinfos

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
   steps:
     - id: run-jfrog-upload-action
       name: run-jfrog-upload-action
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-345e0273ffd4a9cd8dc7a8b9bd5dae2012c5f1d4
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-fd246058f87ac46255af92aa41cbad9a5c8d5c1c
       shell: sh
       env:
         CONFIG_JSON: '{"metaInfo":{"srcType":"upload","url":"${{ inputs.url }}","username":"${{ inputs.username }}","password":"${{ inputs.password }}","token":"${{ inputs.token }}","artifactoryPath":"${{ inputs.artifactory-path }}","filePath":"${{ inputs.file-path }}","send-artifact-info":${{ inputs.send-artifact-info }},"artifact-name":"${{ inputs.artifact-name }}","artifact-version":"${{ inputs.artifact-version }}"}}'


### PR DESCRIPTION
I've verified that fresh jfrog-actions docker image for commit https://github.com/calculi-corp/jfrog-repo-actions/commit/fd246058f87ac46255af92aa41cbad9a5c8d5c1c is already publicly available:

```
docker image pull public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-fd246058f87ac46255af92aa41cbad9a5c8d5c1c
main-fd246058f87ac46255af92aa41cbad9a5c8d5c1c: Pulling from l7o7z1g8/actions/jfrog-actions
35d697fe2738: Already exists
bfb59b82a9b6: Already exists
4eff9a62d888: Already exists
62de241dac5f: Pull complete
2780920e5dbf: Pull complete
7c12895b777b: Pull complete
3214acf345c0: Pull complete
5664b15f108b: Pull complete
045fc1c20da8: Pull complete
4aa0ea1413d3: Pull complete
da7816fa955e: Pull complete
ddf74a63f7d8: Pull complete
7728606be713: Pull complete
fefd890e6bbe: Pull complete
6c69e3ee73e2: Pull complete
Digest: sha256:2f1b72319204ac540bea27709582b3460f7f72647d2f7763b36d671e44225fff
Status: Downloaded newer image for public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-fd246058f87ac46255af92aa41cbad9a5c8d5c1c
public.ecr.aws/l7o7z1g8/actions/jfrog-actions:main-fd246058f87ac46255af92aa41cbad9a5c8d5c1c
```